### PR TITLE
Added requirements_cpu.txt

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -1,0 +1,5 @@
+matplotlib==2.2.3
+numpy==1.19.2
+opencv-python==3.4.8.29
+torch==1.6.0
+torchvision==0.7.0


### PR DESCRIPTION
It seems some of the versions of programs listed don't exist on pip. This was the closest I could get, and this file can be used to quickly install all requirements with `pip install -r requirements_cpu.txt`. This install works for me.

Note, I am running python 3.8.5 on macOS with a MacBook Pro, no GPU support. I think the package for torch might be different when using a GPU, so someone else that has a GPU can make that requirements file with `pip freeze > requirements_gpu.txt` after they get it running in a minimal virtual environment.